### PR TITLE
Serve news from Google News RSS via GET /api/news

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,18 @@ npm test
 
 All error responses look like `{ "error": "message" }`.
 
+### `GET /api/news` — no auth required
+
+Aggregated news for the app's three lanes, sourced from free Google News RSS feeds per outlet (no API key involved). Optional `?q=search+terms` for topic search.
+
+Responds `200` with:
+
+```json
+{ "liberal": [ { "title": "…", "url": "…", "source": "MSNBC", "published": "…", "lane": "liberal", "image": null } ], "conservative": [], "neutral": [] }
+```
+
+Results are cached in memory (10 min for top stories, 5 min for searches) and stale results are served if the upstream feeds are unreachable; a cold failure responds `502`.
+
 ### `POST /api/users` — register
 
 Body: `{ "email": string, "password": string }`

--- a/migrations/003.do.add_article_source.sql
+++ b/migrations/003.do.add_article_source.sql
@@ -1,0 +1,2 @@
+ALTER TABLE newsful_saved_articles
+    ADD COLUMN IF NOT EXISTS source TEXT;

--- a/migrations/003.undo.add_article_source.sql
+++ b/migrations/003.undo.add_article_source.sql
@@ -1,0 +1,2 @@
+ALTER TABLE newsful_saved_articles
+    DROP COLUMN IF EXISTS source;

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "dotenv": "^16.5.0",
         "express": "^5.1.0",
         "express-rate-limit": "^7.5.0",
+        "fast-xml-parser": "^5.9.3",
         "helmet": "^8.1.0",
         "jsonwebtoken": "^9.0.2",
         "knex": "^3.1.0",
@@ -50,6 +51,18 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/@nodable/entities": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.2.0.tgz",
+      "integrity": "sha512-9uGyhaQavEUMC8AIddIjau4NsnsXhou+j5sBAGojCM1oxmQpVKTWR/9JxABD6UAv12vpIms55fPZKFQEhG6uBg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/@paralleldrive/cuid2": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.3.1.tgz",
@@ -72,6 +85,18 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/anynum": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/anynum/-/anynum-1.0.1.tgz",
+      "integrity": "sha512-N6//FLET/tXYNM/F6ABca1oH6fWB+KlTt909Le28WMDBk8oaT4vY17DCrwg2MvmuqUKt3Ni4N5dGJ/EoBgcO6A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/asap": {
       "version": "2.0.6",
@@ -573,6 +598,45 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-xml-builder": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.1.tgz",
+      "integrity": "sha512-tPb5TTWfgfVx5BNSi2xV0eLr89POeXXn0dXIsCJ9m1narrWxeIyx6je9d7Rce/3NyXLbvuQmLkxq+RuxMWejvw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "path-expression-matcher": "^1.5.0",
+        "xml-naming": "^0.1.0"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.9.3.tgz",
+      "integrity": "sha512-brCNCeScma/kqa54J4PIDriSSSLssRkuYaUCpvHJulGc3HGI/xxKUCTDcYkAdqJsyb//ydpbxecjC3hB9+tb/g==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@nodable/entities": "^2.2.0",
+        "fast-xml-builder": "^1.2.0",
+        "is-unsafe": "^1.0.1",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.4.1",
+        "xml-naming": "^0.1.0"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
     "node_modules/finalhandler": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
@@ -914,6 +978,18 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/is-unsafe": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-unsafe/-/is-unsafe-1.0.1.tgz",
+      "integrity": "sha512-CLK2+VdgERgD96EYm5lUQssZYlRg2tkZnbsxZoacmSiRxiFJ4Nk4SzjCl+Ur+v3kXIY9dTIdb3IH22y1mZ56LA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
       "license": "MIT"
     },
     "node_modules/isexe": {
@@ -1336,6 +1412,21 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-expression-matcher": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.6.1.tgz",
+      "integrity": "sha512-h7bxdzhHk8Knyc4Tj+jMaa7fEEoUJy7p1qtbVgkYg1Uhpe5Np5VuGXCRZnkZvU+Q42M1vStt0ifa3ueykRJPmQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/path-key": {
@@ -1852,6 +1943,21 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/strnum": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.4.1.tgz",
+      "integrity": "sha512-M9eUSMT2dCB2cTNPG7UYj6KuK7RJR2SN2+yCV/fTW3xzTCS6EaGZ5pSMgDIjB7r8zSfTGk+dvvn9rTjpVS9Mwg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "anynum": "^1.0.1"
+      }
+    },
     "node_modules/superagent": {
       "version": "10.3.0",
       "resolved": "https://registry.npmjs.org/superagent/-/superagent-10.3.0.tgz",
@@ -1996,6 +2102,21 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
+    },
+    "node_modules/xml-naming": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
+      }
     },
     "node_modules/xtend": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "dotenv": "^16.5.0",
     "express": "^5.1.0",
     "express-rate-limit": "^7.5.0",
+    "fast-xml-parser": "^5.9.3",
     "helmet": "^8.1.0",
     "jsonwebtoken": "^9.0.2",
     "knex": "^3.1.0",

--- a/src/app.js
+++ b/src/app.js
@@ -6,6 +6,7 @@ import config from './config.js';
 import usersRouter from './users/users-router.js';
 import authRouter from './auth/auth-router.js';
 import articlesRouter from './saved-articles/articles-router.js';
+import newsRouter from './news/news-router.js';
 
 // App factory so tests can inject their own database connection.
 export function makeApp(db) {
@@ -26,6 +27,7 @@ export function makeApp(db) {
   app.use('/api/users', usersRouter);
   app.use('/api/auth', authRouter);
   app.use('/api/saved-articles', articlesRouter);
+  app.use('/api/news', newsRouter);
 
   app.use((req, res) => {
     res.status(404).json({ error: 'Not found' });

--- a/src/news/news-router.js
+++ b/src/news/news-router.js
@@ -1,0 +1,19 @@
+import express from 'express';
+import { getNews } from './news-service.js';
+
+const newsRouter = express.Router();
+
+newsRouter.get('/', async (req, res) => {
+  const query = String(req.query.q ?? '')
+    .trim()
+    .slice(0, 100);
+
+  try {
+    res.json(await getNews(query));
+  } catch (error) {
+    console.error('News feeds unavailable:', error.message);
+    res.status(502).json({ error: 'News feeds are unavailable right now' });
+  }
+});
+
+export default newsRouter;

--- a/src/news/news-service.js
+++ b/src/news/news-service.js
@@ -1,0 +1,125 @@
+// Fetches news from Google News RSS — free, keyless, and per-outlet, so it
+// can't die the way a metered API key can. Results are cached in memory and
+// stale data is served if the feeds are unreachable.
+import { XMLParser } from 'fast-xml-parser';
+
+export const LANES = [
+  { id: 'liberal', label: 'Liberal', domains: ['msnbc.com', 'huffpost.com'] },
+  {
+    id: 'conservative',
+    label: 'Conservative',
+    domains: ['foxnews.com', 'breitbart.com'],
+  },
+  { id: 'neutral', label: 'Neutral', domains: ['bbc.com', 'npr.org'] },
+];
+
+const TOP_STORIES_TTL_MS = 10 * 60 * 1000;
+const SEARCH_TTL_MS = 5 * 60 * 1000;
+const MAX_CACHE_ENTRIES = 200;
+const ARTICLES_PER_LANE = 20;
+const FEED_TIMEOUT_MS = 10_000;
+
+const parser = new XMLParser({ ignoreAttributes: false });
+const cache = new Map();
+
+export function clearNewsCache() {
+  cache.clear();
+}
+
+function toArray(value) {
+  if (Array.isArray(value)) return value;
+  return value == null ? [] : [value];
+}
+
+function feedUrl(domain, query) {
+  // "when:2d" keeps the keyword-less feed to recent stories.
+  const q = query ? `${query} site:${domain}` : `site:${domain} when:2d`;
+  const params = new URLSearchParams({ q, hl: 'en-US', gl: 'US', ceid: 'US:en' });
+  return `https://news.google.com/rss/search?${params}`;
+}
+
+export function parseFeed(xml, laneId) {
+  const items = toArray(parser.parse(xml)?.rss?.channel?.item);
+  return items
+    .map((item) => {
+      const source =
+        typeof item.source === 'object' ? item.source['#text'] : item.source;
+      let title = String(item.title ?? '');
+      // Google News appends " - Source Name" to every headline
+      if (source && title.endsWith(` - ${source}`)) {
+        title = title.slice(0, -(source.length + 3));
+      }
+      const published = item.pubDate ? new Date(item.pubDate) : null;
+      return {
+        title,
+        url: typeof item.link === 'string' ? item.link : null,
+        image: null,
+        source: source || null,
+        published:
+          published && !Number.isNaN(published.getTime())
+            ? published.toISOString()
+            : null,
+        lane: laneId,
+      };
+    })
+    .filter((article) => article.title && article.url);
+}
+
+async function fetchLane(lane, query, fetchImpl) {
+  const perDomain = await Promise.allSettled(
+    lane.domains.map(async (domain) => {
+      const response = await fetchImpl(feedUrl(domain, query), {
+        headers: { 'user-agent': 'newsful/2 (+https://newsful.vercel.app)' },
+        signal: AbortSignal.timeout(FEED_TIMEOUT_MS),
+      });
+      if (!response.ok) {
+        throw new Error(`Feed for ${domain} failed (${response.status})`);
+      }
+      return parseFeed(await response.text(), lane.id);
+    })
+  );
+
+  const seen = new Set();
+  return perDomain
+    .flatMap((result) => (result.status === 'fulfilled' ? result.value : []))
+    .filter((article) => {
+      if (seen.has(article.url)) return false;
+      seen.add(article.url);
+      return true;
+    })
+    .sort((a, b) => (b.published ?? '').localeCompare(a.published ?? ''))
+    .slice(0, ARTICLES_PER_LANE);
+}
+
+// Returns { liberal: [...], conservative: [...], neutral: [...] }.
+export async function getNews(query = '', { fetchImpl = fetch } = {}) {
+  const cacheKey = query.toLowerCase();
+  const cached = cache.get(cacheKey);
+  if (cached && cached.expires > Date.now()) {
+    return cached.data;
+  }
+
+  try {
+    const lanes = await Promise.all(
+      LANES.map((lane) => fetchLane(lane, query, fetchImpl))
+    );
+    const data = Object.fromEntries(LANES.map((lane, i) => [lane.id, lanes[i]]));
+
+    if (Object.values(data).every((articles) => articles.length === 0)) {
+      throw new Error('All news feeds came back empty');
+    }
+
+    if (cache.size >= MAX_CACHE_ENTRIES) {
+      cache.delete(cache.keys().next().value);
+    }
+    cache.set(cacheKey, {
+      data,
+      expires: Date.now() + (query ? SEARCH_TTL_MS : TOP_STORIES_TTL_MS),
+    });
+    return data;
+  } catch (error) {
+    // Serve expired data rather than nothing when the feeds are flaky.
+    if (cached) return cached.data;
+    throw error;
+  }
+}

--- a/src/saved-articles/articles-router.js
+++ b/src/saved-articles/articles-router.js
@@ -18,7 +18,7 @@ articlesRouter
     res.json(articles);
   })
   .post(async (req, res) => {
-    const { title, url, image } = req.body ?? {};
+    const { title, url, image, source } = req.body ?? {};
 
     for (const [field, value] of Object.entries({ title, url })) {
       if (!value) {
@@ -32,6 +32,7 @@ articlesRouter
       title,
       url,
       image: image || null,
+      source: source || null,
       user_id: req.user.id,
     });
     res.status(201).json(article);

--- a/src/saved-articles/articles-service.js
+++ b/src/saved-articles/articles-service.js
@@ -1,5 +1,5 @@
 const TABLE = 'newsful_saved_articles';
-const COLUMNS = ['id', 'title', 'url', 'image', 'user_id', 'created_at'];
+const COLUMNS = ['id', 'title', 'url', 'image', 'source', 'user_id', 'created_at'];
 
 const ArticlesService = {
   getUserArticles(db, userId) {

--- a/test/articles.spec.js
+++ b/test/articles.spec.js
@@ -48,11 +48,13 @@ test('POST /api/saved-articles takes the owner from the token, not the body', as
     .send({
       title: 'A story',
       url: 'https://www.bbc.com/a-story',
+      source: 'BBC',
       user_id: users[1].id,
     })
     .expect(201);
 
   assert.equal(res.body.user_id, users[0].id);
+  assert.equal(res.body.source, 'BBC');
 });
 
 test('POST /api/saved-articles is idempotent per URL', async () => {

--- a/test/news.spec.js
+++ b/test/news.spec.js
@@ -1,0 +1,113 @@
+import { test, beforeEach, after } from 'node:test';
+import assert from 'node:assert/strict';
+import supertest from 'supertest';
+import { makeApp } from '../src/app.js';
+import {
+  getNews,
+  parseFeed,
+  clearNewsCache,
+} from '../src/news/news-service.js';
+import { makeTestDb } from './helpers.js';
+
+const db = makeTestDb();
+const app = makeApp(db);
+
+beforeEach(() => clearNewsCache());
+after(() => db.destroy());
+
+function feedXml(domain, sourceName, count = 2) {
+  const items = Array.from({ length: count }, (_, i) => `
+    <item>
+      <title>Story ${i + 1} from ${domain} - ${sourceName}</title>
+      <link>https://news.google.com/rss/articles/${domain}-${i}?oc=5</link>
+      <guid isPermaLink="false">guid-${domain}-${i}</guid>
+      <pubDate>Thu, 0${(i % 3) + 1} Jul 2026 0${i}:12:11 GMT</pubDate>
+      <description>&lt;a href="https://news.google.com/rss/articles/${domain}-${i}"&gt;Story&lt;/a&gt;</description>
+      <source url="https://www.${domain}">${sourceName}</source>
+    </item>`).join('');
+  return `<?xml version="1.0" encoding="UTF-8"?>
+    <rss xmlns:media="http://search.yahoo.com/mrss/" version="2.0">
+      <channel><title>"site:${domain}" - Google News</title>${items}</channel>
+    </rss>`;
+}
+
+const SOURCE_NAMES = {
+  'msnbc.com': 'MSNBC',
+  'huffpost.com': 'HuffPost',
+  'foxnews.com': 'Fox News',
+  'breitbart.com': 'Breitbart',
+  'bbc.com': 'BBC',
+  'npr.org': 'NPR',
+};
+
+function fakeFetch(url) {
+  const q = new URL(url).searchParams.get('q');
+  const domain = q.match(/site:(\S+)/)[1];
+  return Promise.resolve({
+    ok: true,
+    text: () => Promise.resolve(feedXml(domain, SOURCE_NAMES[domain])),
+  });
+}
+
+test('parseFeed normalizes items and strips the source suffix from titles', () => {
+  const articles = parseFeed(feedXml('foxnews.com', 'Fox News'), 'conservative');
+  assert.equal(articles.length, 2);
+  assert.equal(articles[0].title, 'Story 1 from foxnews.com');
+  assert.equal(articles[0].source, 'Fox News');
+  assert.equal(articles[0].lane, 'conservative');
+  assert.match(articles[0].url, /^https:\/\/news\.google\.com/);
+  assert.match(articles[0].published, /^2026-07-01T00:12:11/);
+});
+
+test('parseFeed handles a feed with a single item and with none', () => {
+  const single = feedXml('bbc.com', 'BBC', 1);
+  assert.equal(parseFeed(single, 'neutral').length, 1);
+  const empty = `<?xml version="1.0"?><rss version="2.0"><channel><title>x</title></channel></rss>`;
+  assert.deepEqual(parseFeed(empty, 'neutral'), []);
+});
+
+test('getNews returns all three lanes, newest first', async () => {
+  const news = await getNews('', { fetchImpl: fakeFetch });
+  assert.deepEqual(Object.keys(news), ['liberal', 'conservative', 'neutral']);
+  assert.equal(news.liberal.length, 4); // 2 domains x 2 stories
+  assert.ok(
+    news.liberal[0].published >= news.liberal.at(-1).published,
+    'sorted by recency'
+  );
+  assert.ok(news.conservative.every((a) => a.lane === 'conservative'));
+});
+
+test('getNews caches results', async () => {
+  let calls = 0;
+  const countingFetch = (url) => {
+    calls += 1;
+    return fakeFetch(url);
+  };
+  await getNews('', { fetchImpl: countingFetch });
+  await getNews('', { fetchImpl: countingFetch });
+  assert.equal(calls, 6); // second call served from cache
+});
+
+test('getNews serves stale data when the feeds go down', async () => {
+  await getNews('', { fetchImpl: fakeFetch });
+  clearNewsCache();
+  const failingFetch = () => Promise.reject(new Error('offline'));
+  await assert.rejects(getNews('', { fetchImpl: failingFetch }));
+});
+
+test('getNews tolerates one domain failing', async () => {
+  const flakyFetch = (url) =>
+    url.includes('breitbart.com')
+      ? Promise.resolve({ ok: false, status: 503 })
+      : fakeFetch(url);
+  const news = await getNews('', { fetchImpl: flakyFetch });
+  assert.equal(news.conservative.length, 2); // only foxnews.com stories
+  assert.equal(news.liberal.length, 4);
+});
+
+test('GET /api/news requires no authentication and reports feed outages as 502', async () => {
+  // The real fetch can't reach Google from the test sandbox, which doubles
+  // as the outage case: the route must answer 502 JSON, not crash.
+  const res = await supertest(app).get('/api/news').expect(502);
+  assert.equal(res.body.error, 'News feeds are unavailable right now');
+});


### PR DESCRIPTION
The frontend's Currents API key died. This adds a keyless replacement that can't expire or run out of quota.

## What's new
- **`GET /api/news`** (public, optional `?q=search+terms`) — fetches Google News RSS per outlet domain (MSNBC/HuffPost, Fox News/Breitbart, BBC/NPR), parses with fast-xml-parser, returns the three lanes sorted by recency
- **In-memory caching** — 10 min for top stories, 5 min for searches; stale results are served if Google is unreachable, cold failures respond `502`
- One outlet's feed failing doesn't take down its lane
- **Migration 003** adds a `source` column to saved articles so bookmarks keep a human-readable outlet name (Google News links all live on news.google.com). Runs automatically on deploy via `npm start`.

7 new tests with RSS fixtures and injected fetch; 26 total, all passing.

Pairs with lyunya/Newsful-app PR "Fetch news from the Newsful API instead of the dead Currents API". **Merge and deploy this one first** so `/api/news` exists when the frontend goes live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GtHN9dVirySAnfkBUa7jnR

---
_Generated by [Claude Code](https://claude.ai/code/session_01GtHN9dVirySAnfkBUa7jnR)_