### PR TITLE
Run on Vercel serverless (with Neon Postgres)

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,16 @@ npm run migrate:test
 npm test
 ```
 
+## Deploying (Vercel + Neon)
+
+The repo is set up to run as a single Vercel serverless function (`api/index.js` + `vercel.json`); pending migrations apply themselves on cold start.
+
+1. In [Vercel](https://vercel.com/new), import this repository as a new project (no build settings needed).
+2. In the project's **Storage** tab, create a **Neon** Postgres database (free tier) and connect it — this injects `DATABASE_URL` automatically.
+3. In **Settings → Environment Variables**, add `JWT_SECRET` (e.g. `openssl rand -hex 32`) and redeploy.
+
+It also still runs as a traditional server (`npm start`) on any Node host — migrations run before boot there too.
+
 ## Configuration
 
 | Variable | Purpose | Default |

--- a/api/index.js
+++ b/api/index.js
@@ -1,0 +1,20 @@
+// Vercel serverless entry point. Every route is handled by the same
+// Express app used everywhere else; vercel.json rewrites all paths here.
+import { createDb } from '../src/db.js';
+import { makeApp } from '../src/app.js';
+import { runMigrations } from '../src/migrate.js';
+
+const db = createDb();
+const app = makeApp(db);
+
+// Migrate once per cold start (a fast no-op when already up to date).
+let ready;
+
+export default async function handler(req, res) {
+  ready ??= runMigrations().catch((error) => {
+    ready = undefined; // let the next request retry
+    throw error;
+  });
+  await ready;
+  return app(req, res);
+}

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "main": "src/server.js",
   "engines": {
-    "node": ">=20"
+    "node": "22.x"
   },
   "scripts": {
     "start": "node scripts/migrate.js && node src/server.js",

--- a/scripts/migrate.js
+++ b/scripts/migrate.js
@@ -2,45 +2,22 @@
 // (or TEST_DATABASE_URL with --test). Usage:
 //   npm run migrate            migrate to latest
 //   npm run migrate -- 001     migrate up/down to version 001
-import path from 'node:path';
-import pg from 'pg';
-import Postgrator from 'postgrator';
 import config from '../src/config.js';
+import { runMigrations } from '../src/migrate.js';
 
 const args = process.argv.slice(2);
 const useTestDb = args.includes('--test');
 const targetVersion = args.find((arg) => !arg.startsWith('--')) || 'max';
 
-const connectionString = useTestDb
-  ? config.TEST_DATABASE_URL
-  : config.DATABASE_URL;
-
-const client = new pg.Client({
-  connectionString,
-  ssl: config.DATABASE_SSL ? { rejectUnauthorized: false } : false,
+const applied = await runMigrations({
+  connectionString: useTestDb ? config.TEST_DATABASE_URL : config.DATABASE_URL,
+  targetVersion,
 });
 
-await client.connect();
-
-try {
-  const postgrator = new Postgrator({
-    migrationPattern: path.join(import.meta.dirname, '../migrations/*'),
-    driver: 'pg',
-    database: new URL(connectionString).pathname.slice(1),
-    execQuery: (query) => client.query(query),
-    // Databases migrated by the old postgrator-cli may have recorded
-    // different checksums; migrations are idempotent, so skip validation.
-    validateChecksums: false,
-  });
-
-  const applied = await postgrator.migrate(targetVersion);
-  if (applied.length === 0) {
-    console.log('Already up to date');
-  } else {
-    for (const migration of applied) {
-      console.log(`Applied ${migration.filename}`);
-    }
+if (applied.length === 0) {
+  console.log('Already up to date');
+} else {
+  for (const migration of applied) {
+    console.log(`Applied ${migration.filename}`);
   }
-} finally {
-  await client.end();
 }

--- a/src/db.js
+++ b/src/db.js
@@ -8,5 +8,7 @@ export function createDb(connectionString = config.DATABASE_URL) {
       connectionString,
       ssl: config.DATABASE_SSL ? { rejectUnauthorized: false } : false,
     },
+    // min 0 lets idle serverless instances release their connections
+    pool: { min: 0, max: 5 },
   });
 }

--- a/src/migrate.js
+++ b/src/migrate.js
@@ -1,0 +1,32 @@
+// Applies SQL migrations from ../migrations. Used by scripts/migrate.js
+// (CLI / traditional servers) and api/index.js (serverless cold start).
+import path from 'node:path';
+import pg from 'pg';
+import Postgrator from 'postgrator';
+import config from './config.js';
+
+export async function runMigrations({
+  connectionString = config.DATABASE_URL,
+  targetVersion = 'max',
+} = {}) {
+  const client = new pg.Client({
+    connectionString,
+    ssl: config.DATABASE_SSL ? { rejectUnauthorized: false } : false,
+  });
+
+  await client.connect();
+  try {
+    const postgrator = new Postgrator({
+      migrationPattern: path.join(import.meta.dirname, '../migrations/*'),
+      driver: 'pg',
+      database: new URL(connectionString).pathname.slice(1),
+      execQuery: (query) => client.query(query),
+      // Databases migrated by the old postgrator-cli may have recorded
+      // different checksums; migrations are idempotent, so skip validation.
+      validateChecksums: false,
+    });
+    return await postgrator.migrate(targetVersion);
+  } finally {
+    await client.end();
+  }
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,3 @@
+{
+  "rewrites": [{ "source": "/(.*)", "destination": "/api/index" }]
+}


### PR DESCRIPTION
Moves hosting off Render (sign-in issues) to Vercel — the account that already hosts the frontend.

- `api/index.js` wraps the existing Express app as a single Vercel function; `vercel.json` rewrites every path to it
- Migrations run once per cold start (fast no-op when up to date); migration logic extracted to `src/migrate.js`, CLI unchanged
- knex pool `min: 0` so idle serverless instances release database connections; Node pinned to 22.x
- README documents the Vercel + Neon setup (import repo → create Neon Postgres from the Storage tab → add `JWT_SECRET`)

`npm start` still works for any traditional Node host.

Verified: 26 tests passing, plus the serverless handler exercised directly (health, login, authed saved-articles, 401s) against Postgres 16.

Pairs with lyunya/Newsful-app PR "Point the default API endpoint at Vercel".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GtHN9dVirySAnfkBUa7jnR

---
_Generated by [Claude Code](https://claude.ai/code/session_01GtHN9dVirySAnfkBUa7jnR)_