### PR TITLE
Report startup problems as JSON instead of crashing the function

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -2,7 +2,7 @@ import express from 'express';
 import morgan from 'morgan';
 import cors from 'cors';
 import helmet from 'helmet';
-import config from './config.js';
+import config, { missingProductionConfig } from './config.js';
 import { createDb } from './db.js';
 import { runMigrations } from './migrate.js';
 import usersRouter from './users/users-router.js';
@@ -88,7 +88,21 @@ async function ensureSchema(db) {
   `);
 }
 
+function respondStartupFailure(res, message) {
+  res.statusCode = 500;
+  res.setHeader('content-type', 'application/json');
+  res.end(JSON.stringify({ error: `Startup failed: ${message}` }));
+}
+
 export default async function handler(req, res) {
+  // Answer with the actual problem instead of the platform's opaque
+  // FUNCTION_INVOCATION_FAILED page.
+  const problems = missingProductionConfig();
+  if (problems.length > 0) {
+    console.error('Startup failed:', problems.join('; '));
+    return respondStartupFailure(res, problems.join('; '));
+  }
+
   const db = serverlessApp?.get('db') ?? createDb();
   serverlessApp ??= makeApp(db);
 
@@ -99,7 +113,13 @@ export default async function handler(req, res) {
     ready = undefined; // let the next request retry
     throw error;
   });
-  await ready;
+
+  try {
+    await ready;
+  } catch (error) {
+    console.error('Startup failed:', error);
+    return respondStartupFailure(res, `database setup failed — ${error.message}`);
+  }
 
   return serverlessApp(req, res);
 }

--- a/src/config.js
+++ b/src/config.js
@@ -3,8 +3,24 @@ import 'dotenv/config';
 const NODE_ENV = process.env.NODE_ENV || 'development';
 const isProduction = NODE_ENV === 'production';
 
-if (isProduction && !process.env.JWT_SECRET) {
-  throw new Error('JWT_SECRET must be set in production');
+// Human-readable list of fatal configuration problems. Callers decide how
+// to surface them (the server refuses to boot; the serverless handler
+// answers 500 with the list) — throwing here at import time would only
+// produce an opaque platform crash page.
+export function missingProductionConfig() {
+  if (!isProduction) return [];
+  const problems = [];
+  if (!process.env.JWT_SECRET) {
+    problems.push(
+      "JWT_SECRET is not set — add it in the host's environment variables (generate one with: openssl rand -hex 32)"
+    );
+  }
+  if (!process.env.DATABASE_URL) {
+    problems.push(
+      'DATABASE_URL is not set — connect a Postgres database to this deployment'
+    );
+  }
+  return problems;
 }
 
 export default {
@@ -16,7 +32,7 @@ export default {
   TEST_DATABASE_URL:
     process.env.TEST_DATABASE_URL ||
     'postgresql://postgres@localhost/newsful-test',
-  // Managed Postgres (e.g. Render) requires SSL; local Postgres doesn't.
+  // Managed Postgres (e.g. Neon) requires SSL; local Postgres doesn't.
   DATABASE_SSL: process.env.DATABASE_SSL
     ? process.env.DATABASE_SSL === 'true'
     : isProduction,

--- a/src/server.js
+++ b/src/server.js
@@ -1,6 +1,12 @@
-import config from './config.js';
+import config, { missingProductionConfig } from './config.js';
 import { createDb } from './db.js';
 import { makeApp } from './app.js';
+
+const problems = missingProductionConfig();
+if (problems.length > 0) {
+  console.error(`Refusing to start:\n- ${problems.join('\n- ')}`);
+  process.exit(1);
+}
 
 const db = createDb();
 const app = makeApp(db);


### PR DESCRIPTION
The deployed function answered every request with Vercel's opaque `FUNCTION_INVOCATION_FAILED` page, hiding the real problem. Root cause: `config.js` threw at import time when `JWT_SECRET` was unset in production, and database failures rejected straight out of the handler.

Now:
- `missingProductionConfig()` returns a human-readable list of fatal problems instead of an import-time throw
- The serverless handler answers `500 {"error":"Startup failed: …"}` naming exactly what's missing (`JWT_SECRET`, `DATABASE_URL`) or which database step failed, and logs the full error
- `server.js` still refuses to boot on traditional hosts, listing every problem at once

Verified all four scenarios locally against the real handler: missing JWT_SECRET, missing DATABASE_URL, unreachable database, and fully configured (health + login work). 27/27 tests passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GtHN9dVirySAnfkBUa7jnR

---
_Generated by [Claude Code](https://claude.ai/code/session_01GtHN9dVirySAnfkBUa7jnR)_